### PR TITLE
logout commit

### DIFF
--- a/src/main/java/com/project/securelogin/config/SecurityConfig.java
+++ b/src/main/java/com/project/securelogin/config/SecurityConfig.java
@@ -6,7 +6,6 @@ import com.project.securelogin.service.CustomUserDetailsService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.http.HttpMethod;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -53,13 +52,7 @@ public class SecurityConfig {
                 .formLogin(form -> form
                         .permitAll() // 로그인 페이지는 누구나 접근 가능
                 )
-                .addFilterBefore(new JwtAuthenticationFilter(jwtTokenProvider, customUserDetailsService), UsernamePasswordAuthenticationFilter.class)
-                // 로그아웃 설정
-                .logout(logout -> logout
-                        .logoutUrl("/logout") // 로그아웃 URL 설정
-                        .logoutSuccessUrl("/login?logout") // 로그아웃 성공 시 이동할 페이지 설정
-                        .permitAll() // 로그아웃은 누구나 접근 가능
-                );
+                .addFilterBefore(new JwtAuthenticationFilter(jwtTokenProvider, customUserDetailsService), UsernamePasswordAuthenticationFilter.class);
 
         return httpSecurity.build();
     }

--- a/src/main/java/com/project/securelogin/controller/AuthController.java
+++ b/src/main/java/com/project/securelogin/controller/AuthController.java
@@ -7,10 +7,7 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.AuthenticationException;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/auth")
@@ -33,6 +30,17 @@ public class AuthController {
             Response errorResponse = new Response(HttpStatus.UNAUTHORIZED.value(), "이메일 주소나 비밀번호가 올바르지 않습니다.");
             return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
                     .body(errorResponse);
+        }
+    }
+
+    @DeleteMapping("/logout")
+    public ResponseEntity<Void> logout(@RequestHeader(name = "Refresh-Token") String refreshToken) {
+        boolean logoutSuccess = authService.logout(refreshToken);
+
+        if (logoutSuccess) {
+            return ResponseEntity.noContent().build(); // 204 No Content
+        } else {
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build(); // or INTERNAL_SERVER_ERROR
         }
     }
 

--- a/src/main/java/com/project/securelogin/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/project/securelogin/jwt/JwtAuthenticationFilter.java
@@ -1,5 +1,8 @@
 package com.project.securelogin.jwt;
 
+import com.project.securelogin.domain.CustomUserDetails;
+import com.project.securelogin.service.CustomUserDetailsService;
+import io.jsonwebtoken.ExpiredJwtException;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -7,44 +10,78 @@ import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.security.core.userdetails.UserDetails;
-import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
+import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
 
-// JWT 토큰을 사용해 인증을 처리하는 필터
+@Component
 @RequiredArgsConstructor
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
     private final JwtTokenProvider jwtTokenProvider;
-    private final UserDetailsService userDetailsService;
+    private final CustomUserDetailsService userDetailsService;
 
-    // HTTP 요청을 필터링하여 JWT 토큰을 검증하고, 사용자를 인증한다.
     @Override
-    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain chain) throws IOException, ServletException {
-        // 요청에서 JWT 토큰 추출
-        String token = jwtTokenProvider.resolveToken(request);
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+        try {
+            // JWT 토큰 추출
+            String jwt = jwtTokenProvider.resolveToken(request);
+            if (jwt != null && jwtTokenProvider.validateToken(jwt)) {
+                // 토큰에서 사용자 정보 추출
+                String email = jwtTokenProvider.getEmail(jwt);
 
-        // 추출한 토큰의 유효성 검증
-        if (token != null && jwtTokenProvider.validateToken(token)) {
-            // 통과하면 토큰에서 이메일을 가져온다.
-            String email = jwtTokenProvider.getEmail(token);
+                // 사용자 정보로부터 UserDetails 로드
+                CustomUserDetails userDetails = (CustomUserDetails) userDetailsService.loadUserByUsername(email);
+                // 인증 객체 생성
+                UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(
+                        userDetails, null, userDetails.getAuthorities());
+                authentication.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
 
-            // 이메일을 사용해 사용자 정보를 로드
-            UserDetails userDetails = userDetailsService.loadUserByUsername(email);
-
-            // 사용자 정보와 권한을 사용해 인증 객체를 생성
-            UsernamePasswordAuthenticationToken authenticationToken = new UsernamePasswordAuthenticationToken(userDetails, "", userDetails.getAuthorities());
-
-            // 인증 객체에 요청의 세부 정보를 추가
-            authenticationToken.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
-
-            // SecurityContextHolder를 사용하여 인증 객체를 설정
-            SecurityContextHolder.getContext().setAuthentication(authenticationToken);
+                // SecurityContext에 인증 객체 설정
+                SecurityContextHolder.getContext().setAuthentication(authentication);
+            }
+        } catch (ExpiredJwtException e) {
+            // 만료된 JWT 처리
+            handleTokenExpiration(request, response);
+            return;
+        } catch (Exception e) {
+            // 예외 발생 시 SecurityContext 초기화
+            SecurityContextHolder.clearContext();
         }
-        // 다음 필터 체인으로 제어를 넘긴다.
-        chain.doFilter(request, response);
+
+        // 다음 필터로 요청 전달
+        filterChain.doFilter(request, response);
+    }
+
+    // 토큰 만료 처리 로직
+    private void handleTokenExpiration(HttpServletRequest request, HttpServletResponse response) throws IOException {
+        // Refresh Token 추출
+        String refreshToken = jwtTokenProvider.resolveRefreshToken(request);
+        if (refreshToken != null && jwtTokenProvider.validateToken(refreshToken)) {
+            // Refresh Token이 블랙리스트에 없으면 새로운 Access Token 발급
+            if (!jwtTokenProvider.isRefreshTokenBlacklisted(refreshToken)) {
+                String jwtToken = jwtTokenProvider.createTokenFromRefreshToken(refreshToken);
+                response.setHeader("Authorization", "Bearer " + jwtToken);
+
+                // 새로 발급받은 Access Token으로 UserDetails 로드
+                String email = jwtTokenProvider.getEmail(jwtToken);
+                CustomUserDetails userDetails = (CustomUserDetails) userDetailsService.loadUserByUsername(email);
+
+                // 인증 객체 생성 및 SecurityContext에 설정
+                UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(
+                        userDetails, null, userDetails.getAuthorities());
+                authentication.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
+                SecurityContextHolder.getContext().setAuthentication(authentication);
+            } else {
+                // Refresh Token이 블랙리스트에 있으면 Unauthorized 에러 반환
+                response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "Refresh token is blacklisted");
+            }
+        } else {
+            // 유효하지 않은 Refresh Token일 경우 SecurityContext 초기화 및 Unauthorized 에러 반환
+            SecurityContextHolder.clearContext();
+            response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "Invalid refresh token");
+        }
     }
 }

--- a/src/main/java/com/project/securelogin/repository/JwtTokenRedisRepository.java
+++ b/src/main/java/com/project/securelogin/repository/JwtTokenRedisRepository.java
@@ -1,0 +1,37 @@
+package com.project.securelogin.repository;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Component;
+
+import java.util.concurrent.TimeUnit;
+
+@Component
+@RequiredArgsConstructor
+public class JwtTokenRedisRepository {
+
+    private static final String BLACKLIST_KEY_PREFIX = "jwt:blacklist:";
+    private final RedisTemplate<String, String> redisTemplate;
+
+    // 주어진 JWT 토큰을 블랙리스트에 추가한다. 이미 추가된 경우 false를 반환하고, 성공적으로 추가된 경우 true를 반환한다.
+    public boolean addTokenToBlacklist(String tokenId, long expireInSeconds) {
+        try {
+            String key = BLACKLIST_KEY_PREFIX + tokenId;
+            Boolean result = redisTemplate.opsForValue().setIfAbsent(key, "true", expireInSeconds, TimeUnit.SECONDS);
+            return Boolean.TRUE.equals(result);
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
+
+    // 주어진 JWT 토큰이 블랙리스트에 있는지 여부를 확인한다.
+    public boolean isTokenBlacklisted(String tokenId) {
+        if (redisTemplate == null) {
+            return false;
+        }
+        String key = BLACKLIST_KEY_PREFIX + tokenId;
+        return redisTemplate.hasKey(key);
+    }
+
+}

--- a/src/main/java/com/project/securelogin/service/AuthService.java
+++ b/src/main/java/com/project/securelogin/service/AuthService.java
@@ -37,4 +37,10 @@ public class AuthService {
             throw new AuthenticationException("Authentication failed: " + e.getMessage()) {};
         }
     }
+
+    // Refresh 토큰을 블랙리스트에 추가하고, 성공적으로 추가되면 true를 반환한다.
+    public boolean logout(String token) {
+        return jwtTokenProvider.blacklistRefreshToken(token);
+    }
+
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -24,5 +24,5 @@ spring:
 
 jwt:
   secret: y7ASs-xN-JOwzNVKfIWVmQsWhTa7FHIw0aZ4JPiB6Sk
-  token-validity-in-seconds: 3600
+  token-validity-in-seconds: 1800 # 유효 기간: 30분
   refresh-token-validity-in-seconds: 86400 # 유효 기간: 하루


### PR DESCRIPTION
## Pull Request 요약

로그아웃 개발

### 변경 사항

-  `AuthService`,`AuthController` 에 로그아웃 메서드 추가
- `Redis`를 이용해 블랙리스트를 관리하는 `JwtTokenRedisRepository` 클래스 구현
- `JwtTokenProvider`에 `RefreshToken` 검증, 추출, 블랙리스트 등록과 확인 등 메서드 추가
- `JwtAuthenticationFilter`에 토큰 만료 처리 로직 추가

### 관련 이슈

#4 Add Logout Logic

### 변경된 동작

- 사용자가 /auth/logout 엔드포인트를 통해 로그아웃을 시도할 수 있음
- 로그아웃 성공 시 `204 No Content` 응답 반환
- + 블랙 리스트에 리프레시 토큰의 고유 ID(`jti`)를 키로 하여 추가
- 로그아웃 실패 시 `500 Internal Server Error` 응답 반환

### 테스트 방법

- POSTMAN을 사용하여 /auth/logout 엔드포인트에 DELETE 요청을 보낸다.
- `Refresh-Token`과 `Authorization` 헤더에 담아 전송한다.
- 로그아웃이 정상적으로 처리되었는지 응답 코드를 확인한다.

#### 로그아웃 성공 시
![image](https://github.com/kcm02/JWT_OAuth_Login/assets/112393082/7f2333cd-3e65-430b-9291-a969988bc241)

#### 로그아웃 실패 시
![image](https://github.com/kcm02/JWT_OAuth_Login/assets/112393082/fec58f29-3eec-462c-9930-fa2570257fa8)


### 기타 정보

없음