### PR TITLE
email_verification commit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,10 @@ target/
 !**/src/main/**/target/
 !**/src/test/**/target/
 
+### YML 파일 제외 ###
+*.yml
+!application.yml
+
 ### STS ###
 .apt_generated
 .classpath

--- a/pom.xml
+++ b/pom.xml
@@ -109,6 +109,19 @@
             <version>2.3.1</version>
         </dependency>
 
+        <!-- JavaMailSender -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-mail</artifactId>
+        </dependency>
+
+        <!-- JUnit 5 의존성 추가 -->
+        <dependency>
+            <groupId>org.junit.platform</groupId>
+            <artifactId>junit-platform-launcher</artifactId>
+            <version>1.8.2</version> <!-- 최신 버전으로 업데이트 -->
+            <scope>test</scope>
+        </dependency>
 
 
 

--- a/src/main/java/com/project/securelogin/config/MailConfig.java
+++ b/src/main/java/com/project/securelogin/config/MailConfig.java
@@ -1,0 +1,48 @@
+package com.project.securelogin.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.JavaMailSenderImpl;
+
+import java.util.Properties;
+
+@Configuration
+public class MailConfig {
+
+    @Value("${spring.mail.host}")
+    private String host;
+
+    @Value("${spring.mail.port}")
+    private Integer port;
+
+    @Value("${spring.mail.username}")
+    private String username;
+
+    @Value("${spring.mail.password}")
+    private String password;
+
+    @Value("${spring.mail.properties.mail.smtp.auth}")
+    private String auth;
+
+    @Value("${spring.mail.properties.mail.smtp.starttls.enable}")
+    private String starttlsEnable;
+
+    @Bean
+    public JavaMailSender javaMailSender() {
+        JavaMailSenderImpl mailSender = new JavaMailSenderImpl();
+        mailSender.setHost(host);
+        mailSender.setPort(port);
+        mailSender.setUsername(username);
+        mailSender.setPassword(password);
+
+        Properties props = mailSender.getJavaMailProperties();
+        props.put("mail.transport.protocol", "smtp");
+        props.put("mail.smtp.auth", auth);
+        props.put("mail.smtp.starttls.enable", starttlsEnable);
+        props.put("mail.debug", "true"); // 디버그 모드 활성화 (선택 사항)
+
+        return mailSender;
+    }
+}

--- a/src/main/java/com/project/securelogin/config/SecurityConfig.java
+++ b/src/main/java/com/project/securelogin/config/SecurityConfig.java
@@ -45,7 +45,7 @@ public class SecurityConfig {
                 // HTTP 요청에 대한 인가 규칙 설정
                 .authorizeHttpRequests(auth -> auth
                         // 로그인과 회원가입 페이지는 누구나 접근 가능
-                        .requestMatchers("/login", "/auth/login", "/user/signup", "/").permitAll() // 로그인과 회원가입은 누구나 접근 가능
+                        .requestMatchers("/login", "/auth/login", "/user/signup", "user/verify/**", "/").permitAll() // 로그인과 회원가입은 누구나 접근 가능
                         .anyRequest().authenticated() // 그 외 요청은 인증 필요
                 )
                 // 폼 로그인 설정

--- a/src/main/java/com/project/securelogin/controller/UserController.java
+++ b/src/main/java/com/project/securelogin/controller/UserController.java
@@ -64,4 +64,13 @@ public class UserController {
         }
     }
 
+    // 이메일 인증
+    @GetMapping("/verify/{token}")
+    public ResponseEntity<JsonResponse> verifyEmail(@PathVariable String token) {
+        UserResponseDTO userResponseDTO = userService.verifyEmail(token);
+        JsonResponse response = new JsonResponse(HttpStatus.OK.value(), "이메일 인증이 완료되었습니다.", userResponseDTO);
+        return ResponseEntity.ok(response);
+    }
+
+
 }

--- a/src/main/java/com/project/securelogin/domain/User.java
+++ b/src/main/java/com/project/securelogin/domain/User.java
@@ -43,9 +43,13 @@ public class User {
     private boolean credentialsNonExpired; // 자격 증명 만료 여부
     private boolean enabled; // 계정 활성화 여부
 
-    public void updateUser(UserRequestDTO requestDTO, PasswordEncoder passwordEncoder) {
+    private String mailVerificationToken; // 이메일 인증 토큰
+
+    public void updateUser(UserRequestDTO requestDTO, PasswordEncoder passwordEncoder,String mailVerificationToken) {
         this.username = requestDTO.getUsername();
         this.email = requestDTO.getEmail();
+        this.mailVerificationToken = mailVerificationToken;
+        this.enabled = false;
 
         // 새로운 비밀번호가 null이 아니고, 기존 비밀번호와 다를 때만 인코딩하여 업데이트
         if (requestDTO.getPassword() != null && !requestDTO.getPassword().equals(this.password)) {
@@ -53,5 +57,9 @@ public class User {
         }
     }
 
+    public void enableAccount() {
+        this.enabled = true;
+        this.mailVerificationToken = null;
+    }
 
 }

--- a/src/main/java/com/project/securelogin/mail/MailService.java
+++ b/src/main/java/com/project/securelogin/mail/MailService.java
@@ -1,0 +1,5 @@
+package com.project.securelogin.mail;
+
+public interface MailService {
+    void sendEmail(String to, String verificationUrl, String subject);
+}

--- a/src/main/java/com/project/securelogin/mail/MailServiceImpl.java
+++ b/src/main/java/com/project/securelogin/mail/MailServiceImpl.java
@@ -1,0 +1,22 @@
+package com.project.securelogin.mail;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.mail.SimpleMailMessage;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.stereotype.Service;
+
+@Service
+public class MailServiceImpl implements MailService {
+
+    @Autowired
+    private JavaMailSender mailSender;
+
+    @Override
+    public void sendEmail(String to, String verificationUrl, String subject) {
+        SimpleMailMessage message = new SimpleMailMessage();
+        message.setTo(to);
+        message.setSubject(subject);
+        message.setText("이메일 인증을 완료하려면 아래 링크를 클릭하세요: " + verificationUrl);
+        mailSender.send(message);
+    }
+}

--- a/src/main/java/com/project/securelogin/repository/UserRepository.java
+++ b/src/main/java/com/project/securelogin/repository/UserRepository.java
@@ -11,6 +11,8 @@ public interface UserRepository extends JpaRepository<User, Long> {
 
     Optional<User> findByEmail(String email);
 
+    Optional<User> findByMailVerificationToken(String token);
+
     boolean existsByEmail(String email);
 
 }

--- a/src/main/java/com/project/securelogin/service/UserService.java
+++ b/src/main/java/com/project/securelogin/service/UserService.java
@@ -3,13 +3,14 @@ package com.project.securelogin.service;
 import com.project.securelogin.domain.User;
 import com.project.securelogin.dto.UserRequestDTO;
 import com.project.securelogin.dto.UserResponseDTO;
+import com.project.securelogin.mail.MailService;
 import com.project.securelogin.repository.UserRepository;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
-import java.util.Optional;
+import java.util.UUID;
 
 @Service
 @RequiredArgsConstructor
@@ -18,17 +19,16 @@ public class UserService {
 
     private final UserRepository userRepository;
     private final PasswordEncoder passwordEncoder;
+    private final MailService mailService;
 
+    // 회원 가입
     public UserResponseDTO signUp(UserRequestDTO userRequestDTO) {
-        // 이메일 중복 체크
-        if (isEmailAlreadyExists(userRequestDTO.getEmail())) {
-            throw new IllegalStateException("이미 등록된 이메일입니다.");
-        }
+        validateEmail(userRequestDTO.getEmail()); // 이메일 중복 체크
 
-        // 비밀번호 암호화
         String encodedPassword = encodePassword(userRequestDTO.getPassword());
 
-        // 회원 정보 생성
+        String verificationToken = UUID.randomUUID().toString();
+
         User user = User.builder()
                 .username(userRequestDTO.getUsername())
                 .password(encodedPassword)
@@ -36,33 +36,41 @@ public class UserService {
                 .accountNonExpired(true)
                 .accountNonLocked(true)
                 .credentialsNonExpired(true)
-                .enabled(true)
+                .enabled(false)
+                .mailVerificationToken(verificationToken)
                 .build();
 
-        // 회원 저장
+        sendEmail(user.getEmail(), verificationToken, "회원가입 이메일 인증");
+
         userRepository.save(user);
 
-        // UserResponseDTO 생성
+        return new UserResponseDTO(user.getUsername(), user.getEmail());
+    }
+
+    // 이메일 검증
+    public UserResponseDTO verifyEmail(String token) {
+        User user = findUserByVerificationToken(token);
+        user.enableAccount(); // 엔티티 메서드 사용
+        userRepository.save(user);
         return new UserResponseDTO(user.getUsername(), user.getEmail());
     }
 
     // 회원 정보 조회
     public UserResponseDTO getUserById(Long userId) {
-        Optional<User> user = userRepository.findById(userId);
-        if (user.isPresent()) {
-            return new UserResponseDTO(user.get().getUsername(), user.get().getEmail());
-        } else {
-            throw new IllegalStateException("사용자를 찾을 수 없습니다.");
-        }
+        User user = findUserById(userId);
+        return new UserResponseDTO(user.getUsername(), user.getEmail());
     }
 
     // 회원 정보 수정
     public UserResponseDTO updateUser(Long userId, UserRequestDTO userRequestDTO) {
         return userRepository.findById(userId).map(user -> {
-            if (!user.getEmail().equals(userRequestDTO.getEmail()) && isEmailAlreadyExists(userRequestDTO.getEmail())) {
-                throw new IllegalStateException("이미 등록된 이메일입니다.");
+            if (!user.getEmail().equals(userRequestDTO.getEmail())) {
+                validateEmail(userRequestDTO.getEmail());
             }
-            user.updateUser(userRequestDTO, passwordEncoder);
+            String verificationToken = UUID.randomUUID().toString();
+            user.updateUser(userRequestDTO, passwordEncoder,verificationToken);
+            sendEmail(user.getEmail(), verificationToken, "회원 정보 수정용 이메일 인증");
+
             userRepository.save(user);
             return new UserResponseDTO(user.getUsername(), user.getEmail());
         }).orElseThrow(() -> new IllegalStateException("사용자를 찾을 수 없습니다."));
@@ -70,16 +78,32 @@ public class UserService {
 
     // 회원 삭제
     public void deleteUser(Long userId) {
-        if (userRepository.existsById(userId)) {
-            userRepository.deleteById(userId);
-        } else {
-            throw new IllegalStateException("사용자를 찾을 수 없습니다.");
-        }
+        userRepository.deleteById(userId);
     }
 
     // 이메일 중복 체크 메서드
-    public boolean isEmailAlreadyExists(String email) {
-        return userRepository.existsByEmail(email);
+    private void validateEmail(String email) {
+        if (userRepository.existsByEmail(email)) {
+            throw new IllegalStateException("이미 등록된 이메일입니다.");
+        }
+    }
+
+    // 이메일 전송 메서드
+    private void sendEmail(String email, String verificationToken, String subject) {
+        String verificationUrl = "http://localhost:9090/user/verify/" + verificationToken;
+        mailService.sendEmail(email, verificationUrl, subject);
+    }
+
+    // 토큰을 사용하여 사용자 조회
+    private User findUserByVerificationToken(String token) {
+        return userRepository.findByMailVerificationToken(token)
+                .orElseThrow(() -> new IllegalStateException("유효한 토큰이 없습니다."));
+    }
+
+    // 사용자 ID를 사용하여 사용자 조회
+    private User findUserById(Long userId) {
+        return userRepository.findById(userId)
+                .orElseThrow(() -> new IllegalStateException("사용자를 찾을 수 없습니다."));
     }
 
     // 비밀번호 암호화 메서드

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -2,14 +2,12 @@ server:
   port: 9090
 
 spring:
+  profiles:
+    group:
+      local: db, jwt, mail
+    active: local
   application:
     name: secure-login
-
-  datasource:
-    url: jdbc:mysql://localhost:3306/secure_login
-    username: root
-    password: 1234
-    driver-class-name: com.mysql.cj.jdbc.Driver
 
   jpa:
     hibernate:
@@ -17,12 +15,3 @@ spring:
     properties:
       hibernate:
         dialect: org.hibernate.dialect.MySQL8Dialect
-  data:
-    redis:
-      host: localhost
-      port: 6379
-
-jwt:
-  secret: y7ASs-xN-JOwzNVKfIWVmQsWhTa7FHIw0aZ4JPiB6Sk
-  token-validity-in-seconds: 1800 # 유효 기간: 30분
-  refresh-token-validity-in-seconds: 86400 # 유효 기간: 하루

--- a/src/test/java/com/project/securelogin/controller/EmailVerificationTest.java
+++ b/src/test/java/com/project/securelogin/controller/EmailVerificationTest.java
@@ -1,0 +1,47 @@
+package com.project.securelogin.controller;
+
+import com.project.securelogin.dto.JsonResponse;
+import com.project.securelogin.service.UserService;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+
+@SpringBootTest
+public class EmailVerificationTest {
+
+    @Autowired
+    private WebApplicationContext context;
+
+    private MockMvc mockMvc;
+
+    @MockBean
+    private UserService userService;
+
+    @Test
+    public void testEmailVerificationLink() throws Exception {
+        String token = "67b9c374-f196-47db-9e88-7641c85912e7";
+        String verificationUrl = "/user/verify/" + token;
+
+        // Mock 객체 설정
+        JsonResponse jsonResponse = new JsonResponse(HttpStatus.OK.value(), "이메일 인증이 완료되었습니다.", null);
+        when(userService.verifyEmail(anyString())).thenReturn(jsonResponse.getData());
+
+        // MockMvc를 이용한 요청 및 응답 검증
+        mockMvc = MockMvcBuilders.webAppContextSetup(context).build();
+        mockMvc.perform(MockMvcRequestBuilders.get(verificationUrl))
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andExpect(MockMvcResultMatchers.content().json("{\"status\":200,\"message\":\"이메일 인증이 완료되었습니다.\",\"data\":null}"));
+    }
+}


### PR DESCRIPTION
# Pull Request 요약

이메일 인증 기능 추가

### 변경 사항

1. **이메일 인증 기능 추가**
   - `MailService`와 `MailServiceImpl` 클래스를 추가하여 이메일 전송 기능 구현
   - `User` 엔티티에 `mailVerificationToken` 필드 추가
   - `UserService`에서 회원 가입, 정보 수정시 이메일 인증 토큰을 생성하고, 이메일을 전송하는 로직 추가
   - `UserController`에 이메일 인증 엔드포인트 추가
   - `SecurityConfig`에 이메일 인증 엔드포인트를  `permitAll()` 설정

2. **테스트 코드 추가**
   - `EmailVerificationTest` 클래스 추가하여 이메일 인증 링크 테스트

3. **`.gitignore` 업데이트**
   -  `application.yml`을 제외한 모든 `.yml` 파일 제외

### 관련 이슈

- #6 에 이메일 인증 기능 추가

### 변경된 동작

- 회원 가입 시 이메일 인증을 요구하게 되어, 사용자가 이메일을 통해 계정을 활성화해야 한다.
- 이메일 인증 전까진 회원이 비활성화(`enabled = false`)되어 로그인할 수 없다.
- 사용자 정보 수정 시 이메일 인증을 요구하게 되어, 새로운 이메일 주소 변경 시에도 인증이 필요하다.

### 테스트 방법

1. **회원 가입 테스트**
   - `/user/signup` 엔드포인트를 통해 회원 가입 요청을 보낸다.
   - 가입한 이메일 주소로 전송된 인증 링크를 클릭하여 계정을 활성화한다.

2. **이메일 인증 테스트**
   - 이메일로 전송된 링크를 클릭한다.
![스크린샷 2024-07-15 142634](https://github.com/user-attachments/assets/89ec2d2a-d641-4ad7-8a2b-6560302ec207)

   - 응답 상태와 메시지를 확인하여 인증이 완료되었는지 확인한다.
![스크린샷 2024-07-15 132030](https://github.com/user-attachments/assets/fdf4547c-b484-4d80-8d4d-0c194e39da36)

### 기타 정보
없음