### PR TITLE
account_lock commit

### DIFF
--- a/src/main/java/com/project/securelogin/controller/AuthController.java
+++ b/src/main/java/com/project/securelogin/controller/AuthController.java
@@ -1,6 +1,8 @@
 package com.project.securelogin.controller;
 
 import com.project.securelogin.dto.JsonResponse;
+import com.project.securelogin.exception.UserAccountLockedException;
+import com.project.securelogin.exception.UserNotEnabledException;
 import com.project.securelogin.service.AuthService;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
@@ -8,6 +10,7 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -21,29 +24,36 @@ public class AuthController {
     public ResponseEntity<JsonResponse> login(@RequestBody AuthRequest authRequest) {
         try {
             HttpHeaders headers = authService.login(authRequest.getEmail(), authRequest.getPassword());
-
-            JsonResponse response = new JsonResponse(HttpStatus.OK.value(),  "로그인에 성공했습니다.", null);
-
-            return ResponseEntity.ok()
-                    .headers(headers)
-                    .body(response);
-        } catch (AuthenticationException e) {
-            JsonResponse errorResponse = new JsonResponse(HttpStatus.UNAUTHORIZED.value(), "이메일 주소나 비밀번호가 올바르지 않습니다.", null);
+            JsonResponse response = new JsonResponse(HttpStatus.OK.value(), "로그인에 성공했습니다.", null);
+            return ResponseEntity.ok().headers(headers).body(response);
+        } catch (UsernameNotFoundException e) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                    .body(new JsonResponse(HttpStatus.NOT_FOUND.value(), e.getMessage(), null));
+        } catch (UserNotEnabledException e) {
             return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
-                    .body(errorResponse);
+                    .body(new JsonResponse(HttpStatus.UNAUTHORIZED.value(), e.getMessage(), null));
+        } catch (UserAccountLockedException e) {
+            return ResponseEntity.status(HttpStatus.LOCKED)
+                    .body(new JsonResponse(HttpStatus.LOCKED.value(), e.getMessage(), null));
+        } catch (AuthenticationException e) {
+            int remainingAttempts = authService.getRemainingLoginAttempts(authRequest.getEmail());
+            String message = "이메일 주소나 비밀번호가 올바르지 않습니다. " +
+                    remainingAttempts + "번 더 로그인에 실패하면 계정이 잠길 수 있습니다.";
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
+                    .body(new JsonResponse(HttpStatus.UNAUTHORIZED.value(), message, null));
         }
     }
+
 
     @DeleteMapping("/logout")
     public ResponseEntity<JsonResponse> logout(@RequestHeader(name = "Refresh-Token") String refreshToken) {
         boolean logoutSuccess = authService.logout(refreshToken);
 
         if (logoutSuccess) {
-            JsonResponse response = new JsonResponse(HttpStatus.NO_CONTENT.value(), "성공적으로 로그아웃되었습니다.", null);
-            return ResponseEntity.ok().body(response); // 204 No Content
+            return ResponseEntity.noContent().build(); // 204 No Content
         } else {
-            JsonResponse errorResponse = new JsonResponse(HttpStatus.INTERNAL_SERVER_ERROR.value(), "잘못된 접근입니다.", null);
-            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(errorResponse); // or INTERNAL_SERVER_ERROR
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                    .body(new JsonResponse(HttpStatus.INTERNAL_SERVER_ERROR.value(), "잘못된 접근입니다.", null));
         }
     }
 
@@ -52,5 +62,5 @@ public class AuthController {
         private String email;
         private String password;
     }
-
 }
+

--- a/src/main/java/com/project/securelogin/controller/UserController.java
+++ b/src/main/java/com/project/securelogin/controller/UserController.java
@@ -20,9 +20,14 @@ public class UserController {
     @PostMapping("/signup")
     // @Valid 어노테이션을 사용해 `SignUpRequest`의 유효성 검사를 활성화, 통과한 경우 서비스 코드 호출
     public ResponseEntity<JsonResponse> signUp(@Valid @RequestBody UserRequestDTO userRequestDTO) {
-        UserResponseDTO userResponseDTO = userService.signUp(userRequestDTO);
-        JsonResponse response = new JsonResponse(HttpStatus.CREATED.value(), "회원 가입이 성공적으로 실행되었습니다.", userResponseDTO);
-        return ResponseEntity.ok().body(response);
+        try {
+            UserResponseDTO userResponseDTO = userService.signUp(userRequestDTO);
+            JsonResponse response = new JsonResponse(HttpStatus.CREATED.value(), "회원 가입이 성공적으로 실행되었습니다. 이메일 인증을 완료해주세요.", userResponseDTO);
+            return ResponseEntity.ok().body(response);
+        } catch (IllegalStateException e) {
+            JsonResponse errorResponse = new JsonResponse(HttpStatus.BAD_REQUEST.value(), "이미 등록된 이메일입니다.", null);
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(errorResponse);
+        }
     }
 
     // 회원 정보 조회
@@ -43,7 +48,7 @@ public class UserController {
     public ResponseEntity<JsonResponse> updateUser(@PathVariable Long userId, @Valid @RequestBody UserRequestDTO userRequestDTO) {
         try {
             UserResponseDTO userResponseDTO = userService.updateUser(userId, userRequestDTO);
-            JsonResponse response = new JsonResponse(HttpStatus.OK.value(), "회원 정보를 성공적으로 수정했습니다.", userResponseDTO);
+            JsonResponse response = new JsonResponse(HttpStatus.OK.value(), "회원 정보를 성공적으로 수정했습니다. 이메일 인증을 완료해주세요.", userResponseDTO);
             return ResponseEntity.ok().body(response);
         } catch (IllegalStateException e) {
             JsonResponse errorResponse = new JsonResponse(HttpStatus.BAD_REQUEST.value(), e.getMessage(), null);

--- a/src/main/java/com/project/securelogin/domain/CustomUserDetails.java
+++ b/src/main/java/com/project/securelogin/domain/CustomUserDetails.java
@@ -1,47 +1,77 @@
 package com.project.securelogin.domain;
 
 import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
 
 import java.util.Collection;
+import java.util.Collections;
 
 @Getter
-@RequiredArgsConstructor
 public class CustomUserDetails implements UserDetails {
 
-    private final String username; // 사용자 이름
-    private final String password; // 비밀번호
-    private final String email; // 이메일
-    private final boolean accountNonExpired; // 계정 만료 여부
-    private final boolean accountNonLocked; // 계정 잠김 여부
-    private final boolean credentialsNonExpired; // 자격 증명 만료 여부
-    private final boolean enabled; // 계정 활성화 여부
-    private final Collection<? extends GrantedAuthority> authorities; // 사용자 권한 목록
+    private final User user;
+
+    public CustomUserDetails(User user) {
+        this.user = user;
+    }
 
     @Override
     public Collection<? extends GrantedAuthority> getAuthorities() {
-        return authorities;
+        return Collections.emptyList();
+    }
+
+    @Override
+    public String getPassword() {
+        return user.getPassword();
+    }
+
+    @Override
+    public String getUsername() {
+        return user.getEmail();
     }
 
     @Override
     public boolean isAccountNonExpired() {
-        return accountNonExpired;
+        return user.isAccountNonExpired();
     }
 
     @Override
     public boolean isAccountNonLocked() {
-        return accountNonLocked;
+        return user.isAccountNonLocked();
     }
 
     @Override
     public boolean isCredentialsNonExpired() {
-        return credentialsNonExpired;
+        return user.isCredentialsNonExpired();
     }
 
     @Override
     public boolean isEnabled() {
-        return enabled;
+        return user.isEnabled();
+    }
+
+    public int getFailedLoginAttempts() {
+        return user.getFailedLoginAttempts();
+    }
+
+    public void incrementFailedLoginAttempts() {
+        user.incrementFailedLoginAttempts();
+    }
+
+    public void resetFailedLoginAttempts() {
+        user.resetFailedLoginAttempts();
+    }
+
+    public void lockAccount() {
+        user.lockAccount();
+    }
+
+    public void unlockAccount() {
+        user.unlockAccount();
+    }
+
+    public boolean isLockTimeExpired(int lockDurationMinutes) {
+        return user.isLockTimeExpired(lockDurationMinutes);
     }
 }

--- a/src/main/java/com/project/securelogin/domain/User.java
+++ b/src/main/java/com/project/securelogin/domain/User.java
@@ -45,6 +45,9 @@ public class User {
 
     private String mailVerificationToken; // 이메일 인증 토큰
 
+    private int failedLoginAttempts; // 로그인 시도 횟수
+    private LocalDateTime lockTime; // 계정 잠금 해제 시간
+
     public void updateUser(UserRequestDTO requestDTO, PasswordEncoder passwordEncoder,String mailVerificationToken) {
         this.username = requestDTO.getUsername();
         this.email = requestDTO.getEmail();
@@ -60,6 +63,36 @@ public class User {
     public void enableAccount() {
         this.enabled = true;
         this.mailVerificationToken = null;
+    }
+
+    // 로그인 실패 시 로그인 시도 횟수 증가
+    public void incrementFailedLoginAttempts() {
+        this.failedLoginAttempts++;
+    }
+
+    // 로그인 성공 시 로그인 시도 횟수 초기화
+    public void resetFailedLoginAttempts() {
+        this.failedLoginAttempts = 0;
+    }
+
+    // 계정 잠금
+    public void lockAccount() {
+        this.accountNonLocked = false;
+        this.lockTime = LocalDateTime.now();
+    }
+
+    // 계정 잠금 풀기
+    public void unlockAccount() {
+        this.accountNonLocked = true;
+        this.lockTime = null;
+    }
+
+    public boolean isLockTimeExpired(int lockDurationMinutes) {
+        if (this.lockTime == null) {
+            return true; // 잠금 시간이 없으면 바로 해제 가능
+        }
+        LocalDateTime expiryTime = this.lockTime.plusMinutes(lockDurationMinutes);
+        return expiryTime.isBefore(LocalDateTime.now()); // 현재 시간이 잠금 만료 시간 이전이면 해제 가능
     }
 
 }

--- a/src/main/java/com/project/securelogin/exception/UserAccountLockedException.java
+++ b/src/main/java/com/project/securelogin/exception/UserAccountLockedException.java
@@ -1,0 +1,9 @@
+package com.project.securelogin.exception;
+
+import org.springframework.security.core.AuthenticationException;
+
+public class UserAccountLockedException extends AuthenticationException {
+    public UserAccountLockedException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/project/securelogin/exception/UserNotEnabledException.java
+++ b/src/main/java/com/project/securelogin/exception/UserNotEnabledException.java
@@ -1,0 +1,9 @@
+package com.project.securelogin.exception;
+
+import org.springframework.security.core.AuthenticationException;
+
+public class UserNotEnabledException extends AuthenticationException {
+    public UserNotEnabledException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/project/securelogin/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/project/securelogin/jwt/JwtTokenProvider.java
@@ -120,7 +120,7 @@ public class JwtTokenProvider {
     // JWT 토큰 생성
     private String generateToken(Authentication authentication, long validitySeconds) {
         CustomUserDetails userDetails = (CustomUserDetails) authentication.getPrincipal();
-        Claims claims = Jwts.claims().setSubject(userDetails.getEmail());
+        Claims claims = Jwts.claims().setSubject(userDetails.getUsername());
 
         Date now = new Date();
         Date validity = new Date(now.getTime() + validitySeconds * 1000);

--- a/src/main/java/com/project/securelogin/service/AuthService.java
+++ b/src/main/java/com/project/securelogin/service/AuthService.java
@@ -15,12 +15,15 @@ public class AuthService {
 
     private final AuthenticationManager authenticationManager;
     private final JwtTokenProvider jwtTokenProvider;
+    private final CustomUserDetailsService userDetailsService;
 
     public HttpHeaders login(String email, String password) {
         try {
             // 인증 수행
             Authentication authentication = authenticationManager.authenticate(
                     new UsernamePasswordAuthenticationToken(email, password));
+
+            userDetailsService.processSuccessfulLogin(email);
 
             // 토큰 생성
             String accessToken = jwtTokenProvider.createToken(authentication);
@@ -33,14 +36,19 @@ public class AuthService {
 
             return headers;
         } catch (AuthenticationException e) {
-            // 인증 실패 시 예외 처리
-            throw new AuthenticationException("Authentication failed: " + e.getMessage()) {};
+            // 로그인 실패 처리
+            userDetailsService.handleAccountStatus(email);
+            userDetailsService.processFailedLogin(email);
+            // 예외를 던짐
+            throw e;
         }
     }
 
-    // Refresh 토큰을 블랙리스트에 추가하고, 성공적으로 추가되면 true를 반환한다.
     public boolean logout(String token) {
         return jwtTokenProvider.blacklistRefreshToken(token);
     }
 
+    public int getRemainingLoginAttempts(String email) {
+        return userDetailsService.getRemainingLoginAttempts(email);
+    }
 }

--- a/src/main/java/com/project/securelogin/service/CustomUserDetailsService.java
+++ b/src/main/java/com/project/securelogin/service/CustomUserDetailsService.java
@@ -2,6 +2,8 @@ package com.project.securelogin.service;
 
 import com.project.securelogin.domain.CustomUserDetails;
 import com.project.securelogin.domain.User;
+import com.project.securelogin.exception.UserAccountLockedException;
+import com.project.securelogin.exception.UserNotEnabledException;
 import com.project.securelogin.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.userdetails.UserDetails;
@@ -9,31 +11,70 @@ import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Service;
 
-import java.util.Collections;
-
 @Service
 @RequiredArgsConstructor
 public class CustomUserDetailsService implements UserDetailsService {
 
     private final UserRepository userRepository;
 
-    @Override // 이메일을 기준으로 사용자를 로드하는 메서드
-    public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
-        // 이메일로 사용자 조회
-        User user = userRepository.findByEmail(email)
-                .orElseThrow(() -> new UsernameNotFoundException("해당 이메일을 가진 사용자를 찾을 수 없습니다: " + email));
+    private static final int MAX_FAILED_ATTEMPTS = 3;
+    private static final int LOCKOUT_MINUTES = 1;
 
-        // 조회된 사용자 정보를 기반으로 CustomUserDetails 객체 생성 후 반환
-        return new CustomUserDetails(
-                user.getUsername(),
-                user.getPassword(),
-                user.getEmail(),
-                user.isAccountNonExpired(), // 계정 만료 여부
-                user.isAccountNonLocked(), // 계정 잠김 여부
-                user.isCredentialsNonExpired(), // 자격 증명 만료 여부
-                user.isEnabled(), // 계정 활성화 여부
-                Collections.emptyList()
-        );
+    @Override
+    public UserDetails loadUserByUsername(String email) {
+        User user = findUserByEmail(email);
 
+        // 잠금 해제 처리
+        if (!user.isAccountNonLocked() && user.isLockTimeExpired(LOCKOUT_MINUTES)) {
+            user.unlockAccount();
+            user.resetFailedLoginAttempts();
+            userRepository.save(user);
+        }
+
+        return new CustomUserDetails(user);
+    }
+
+    private User findUserByEmail(String email) {
+        return userRepository.findByEmail(email)
+                .orElseThrow(() -> new UsernameNotFoundException("해당 이메일을 가진 사용자를 찾을 수 없습니다."));
+    }
+
+    public void handleAccountStatus(String email) {
+        User user = findUserByEmail(email);
+
+        // 계정이 활성화되지 않은 경우 예외 발생
+        if (!user.isEnabled()) {
+            throw new UserNotEnabledException("계정이 활성화되지 않았습니다. 이메일 인증을 완료해주세요.");
+        }
+
+        // 계정이 잠금된 경우 예외 발생
+        if (!user.isAccountNonLocked()) {
+            throw new UserAccountLockedException("계정이 잠금되었습니다. " + user.getLockTime().plusMinutes(LOCKOUT_MINUTES) + " 이후에 다시 시도해주세요.");
+        }
+    }
+
+    public void processFailedLogin(String email) {
+        userRepository.findByEmail(email).ifPresent(user -> {
+            user.incrementFailedLoginAttempts();
+            if (user.getFailedLoginAttempts() >= MAX_FAILED_ATTEMPTS) {
+                user.lockAccount();
+            }
+            userRepository.save(user);
+        });
+    }
+
+    public void processSuccessfulLogin(String email) {
+        userRepository.findByEmail(email).ifPresent(user -> {
+            user.resetFailedLoginAttempts();
+            userRepository.save(user);
+        });
+    }
+
+    public int getRemainingLoginAttempts(String email) {
+        return userRepository.findByEmail(email)
+                .map(User::getFailedLoginAttempts)
+                .filter(attempts -> attempts < MAX_FAILED_ATTEMPTS) // 잠금 전까지만 표시
+                .map(attempts -> MAX_FAILED_ATTEMPTS - attempts + 1)
+                .orElse(1);
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -11,7 +11,7 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: create
+      ddl-auto: update
     properties:
       hibernate:
         dialect: org.hibernate.dialect.MySQL8Dialect


### PR DESCRIPTION
## Pull Request 요약

> _**계정 잠금 기능 추가**_

- 사용자 로그인 실패 시 계정을 잠금 처리하고, 잠금 해제를 관리하는 기능을 추가한다. 
- 로그인 실패 횟수를 추적하고 최대 실패 횟수를 초과할 경우 계정을 잠그며, 일정 시간이 지나면 자동으로 잠금이 해제된다.

### 변경 사항

1. **AuthController.java**:
    - 로그인 API의 예외 처리 강화
    - 인증 예외 처리 로직 수정

2. **UserController.java**:
    - 회원 가입 및 정보 수정 시 이메일 인증 관련 메시지 추가
    - 예외 처리 로직 수정

3. **User.java**:
    - 로그인 실패 횟수 증가, 초기화, 계정 잠금 및 잠금 해제 관련 메서드 추가

4. **CustomUserDetailsService.java**:
    - `loadUserByUsername` 메서드 수정
    - 로그인 성공 시, 실패 시 실행될 메서드 추가

5. **AuthService.java**:
    - 로그인 실패 시 로그인 시도 횟수를 증가시키고, 실패 횟수가 최대치를 초과할 경우 계정을 잠그는 로직 추가
    - 로그인 성공 시 로그인 시도 횟수를 초기화하는 로직 추가

6. **UserAccountLockedException.java**:
    - 계정 잠금 예외 클래스 추가

7. **UserNotEnabledException.java**:
    - 계정 비활성화 예외 클래스 추가

8. **application.yml**:
    - JPA 설정을 'create'에서 'update'로 변경

### 관련 이슈

#8 에 계정 잠금 처리 기능 추가

### 변경된 동작

- 사용자 로그인 실패 시 실패 횟수를 증가시키고, 최대 실패 횟수를 초과할 경우 계정을 잠금 처리한다.
- 일정 시간이 지나면 계정 잠금이 자동으로 해제된다.
- 로그인 성공 시 실패 횟수를 초기화한다.

### 테스트 방법

#### 예외 처리
![image](https://github.com/user-attachments/assets/7d19a3f0-c13e-4c60-ba39-989eacf350a5)
![image](https://github.com/user-attachments/assets/6fdb48e0-6b5c-4fa7-a5df-d71685d15307)

만약 DB에 존재하지 않는 이메일을 입력하거나, 이메일 인증을 완료하기 전 로그인을 시도하면 각각 알맞은 메시지를 반환한다.

#### 계정 잠금
![image](https://github.com/user-attachments/assets/ead4083d-961f-4693-a407-5c790e357789)
![image](https://github.com/user-attachments/assets/de6aff84-0b05-40f1-9509-344f6b91f87d)
![image](https://github.com/user-attachments/assets/da06d3c5-d012-47b8-a0bc-3eec3114462d)

만약 로그인을 3번 이상 실패하면, 계정이 잠금 처리가 되고 DB에도 잘 반영되는 것을 확인할 수 있다.

#### 잠금 해제
![image](https://github.com/user-attachments/assets/5edeeace-ec90-466c-8c05-fbffd07672b2)
![image](https://github.com/user-attachments/assets/4f36f95c-1c95-44b4-9946-dafb706f01b6)

일정 시간이 지나서 로그인 시도를 하면 정상적으로 처리되고, DB에도 잠금 처리가 풀린 것을 확인할 수 있다.

### 기타 정보

- 테스트를 위해 임시로 잠금 해제 시간을 1분으로 설정
- 로그인 실패 횟수의 최대치, 잠금 해제 시간은 `static` 변수로 설정