### PR TITLE
OAuth2_Login commit

### DIFF
--- a/src/main/java/com/project/securelogin/config/SecurityConfig.java
+++ b/src/main/java/com/project/securelogin/config/SecurityConfig.java
@@ -2,6 +2,9 @@ package com.project.securelogin.config;
 
 import com.project.securelogin.jwt.JwtAuthenticationFilter;
 import com.project.securelogin.jwt.JwtTokenProvider;
+import com.project.securelogin.oauth.handler.OAuth2LoginFailureHandler;
+import com.project.securelogin.oauth.handler.OAuth2LoginSuccessHandler;
+import com.project.securelogin.service.CustomOAuth2UserService;
 import com.project.securelogin.service.CustomUserDetailsService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
@@ -24,6 +27,9 @@ public class SecurityConfig {
 
     private final CustomUserDetailsService customUserDetailsService;
     private final JwtTokenProvider jwtTokenProvider;
+    private final CustomOAuth2UserService customOAuth2UserService;
+    private final OAuth2LoginSuccessHandler oauth2LoginSuccessHandler;
+    private final OAuth2LoginFailureHandler oauth2LoginFailureHandler;
 
     @Bean // 비밀번호 암호화를 위한 PasswordEncoder 빈 생성
     public PasswordEncoder passwordEncoder() {
@@ -51,6 +57,15 @@ public class SecurityConfig {
                 // 폼 로그인 설정
                 .formLogin(form -> form
                         .permitAll() // 로그인 페이지는 누구나 접근 가능
+                )
+                // OAuth 로그인 설정
+                .oauth2Login(oauth2 -> oauth2
+                        .loginPage("/login")
+                        .failureHandler(oauth2LoginFailureHandler)
+                        .successHandler(oauth2LoginSuccessHandler)
+                        .userInfoEndpoint(userInfo -> userInfo
+                                .userService(customOAuth2UserService)
+                        )
                 )
                 .addFilterBefore(new JwtAuthenticationFilter(jwtTokenProvider, customUserDetailsService), UsernamePasswordAuthenticationFilter.class);
 

--- a/src/main/java/com/project/securelogin/domain/CustomOAuth2User.java
+++ b/src/main/java/com/project/securelogin/domain/CustomOAuth2User.java
@@ -1,0 +1,96 @@
+package com.project.securelogin.domain;
+
+import lombok.Getter;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+@Getter
+public class CustomOAuth2User implements OAuth2User {
+
+    private final OAuth2User oAuth2User;
+    private final String socialType;
+    private final String id;
+    private final String name;
+    private final String email;
+
+    public CustomOAuth2User(OAuth2User oAuth2User, String socialType) {
+        this.oAuth2User = oAuth2User;
+        this.socialType = socialType;
+        this.id = extractId(oAuth2User, socialType);
+        this.name = extractName(oAuth2User, socialType);
+        this.email = extractEmail(oAuth2User, socialType);
+    }
+
+    private String extractId(OAuth2User oAuth2User, String socialType) {
+        switch (socialType) {
+            case "google":
+                return (String) oAuth2User.getAttribute("sub");
+            case "kakao":
+                Object id = oAuth2User.getAttribute("id");
+                return id != null ? id.toString() : null; // Long 타입을 String으로 변환
+            case "naver":
+                Map<String, Object> response = (Map<String, Object>) oAuth2User.getAttribute("response");
+                return (String) response.get("id");
+            default:
+                throw new IllegalArgumentException("Unsupported social type: " + socialType);
+        }
+    }
+
+
+    private String extractName(OAuth2User oAuth2User, String socialType) {
+        switch (socialType) {
+            case "google":
+                return (String) oAuth2User.getAttribute("name");
+            case "kakao":
+                Map<String, Object> account = (Map<String, Object>) oAuth2User.getAttribute("kakao_account");
+                Map<String, Object> profile = (Map<String, Object>) account.get("profile");
+                return (String) profile.get("nickname");
+            case "naver":
+                Map<String, Object> response = (Map<String, Object>) oAuth2User.getAttribute("response");
+                return (String) response.get("name");
+            default:
+                throw new IllegalArgumentException("Unsupported social type: " + socialType);
+        }
+    }
+
+    private String extractEmail(OAuth2User oAuth2User, String socialType) {
+        switch (socialType) {
+            case "google":
+                return (String) oAuth2User.getAttribute("email");
+            case "kakao":
+                Map<String, Object> account = (Map<String, Object>) oAuth2User.getAttribute("kakao_account");
+                return (String) account.get("email");
+            case "naver":
+                Map<String, Object> response = (Map<String, Object>) oAuth2User.getAttribute("response");
+                return (String) response.get("email");
+            default:
+                throw new IllegalArgumentException("Unsupported social type: " + socialType);
+        }
+    }
+
+    @Override
+    public Map<String, Object> getAttributes() {
+        return oAuth2User.getAttributes();
+    }
+
+    @Override
+    public Object getAttribute(String name) {
+        return oAuth2User.getAttribute(name);
+    }
+
+    @Override
+    public String getName() {
+        return name;
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        // 빈 권한 목록을 반환합니다.
+        return Set.of();
+    }
+}

--- a/src/main/java/com/project/securelogin/domain/CustomUserDetails.java
+++ b/src/main/java/com/project/securelogin/domain/CustomUserDetails.java
@@ -51,27 +51,5 @@ public class CustomUserDetails implements UserDetails {
         return user.isEnabled();
     }
 
-    public int getFailedLoginAttempts() {
-        return user.getFailedLoginAttempts();
-    }
 
-    public void incrementFailedLoginAttempts() {
-        user.incrementFailedLoginAttempts();
-    }
-
-    public void resetFailedLoginAttempts() {
-        user.resetFailedLoginAttempts();
-    }
-
-    public void lockAccount() {
-        user.lockAccount();
-    }
-
-    public void unlockAccount() {
-        user.unlockAccount();
-    }
-
-    public boolean isLockTimeExpired(int lockDurationMinutes) {
-        return user.isLockTimeExpired(lockDurationMinutes);
-    }
 }

--- a/src/main/java/com/project/securelogin/domain/User.java
+++ b/src/main/java/com/project/securelogin/domain/User.java
@@ -23,13 +23,10 @@ public class User {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(nullable = false)
     private String username;
 
-    @Column(nullable = false)
     private String password;
 
-    @Column(nullable = false)
     private String email;
 
     @CreationTimestamp
@@ -47,6 +44,9 @@ public class User {
 
     private int failedLoginAttempts; // 로그인 시도 횟수
     private LocalDateTime lockTime; // 계정 잠금 해제 시간
+
+    private String socialType; // 소셜 타입 (자체 로그인의 경우 Null)
+    private String socialId; // 소셜 ID  (자체 로그인의 경우 Null)
 
     public void updateUser(UserRequestDTO requestDTO, PasswordEncoder passwordEncoder,String mailVerificationToken) {
         this.username = requestDTO.getUsername();
@@ -93,6 +93,16 @@ public class User {
         }
         LocalDateTime expiryTime = this.lockTime.plusMinutes(lockDurationMinutes);
         return expiryTime.isBefore(LocalDateTime.now()); // 현재 시간이 잠금 만료 시간 이전이면 해제 가능
+    }
+
+    public void updateOAuthUser(String username, String email, String socialType, String socialId) {
+        this.username = username;
+        if (email != null) {
+            this.email = email;
+        }
+        this.socialType = socialType;
+        this.socialId = socialId;
+        this.enabled = true; // OAuth 로그인 후 사용자는 활성화 상태
     }
 
 }

--- a/src/main/java/com/project/securelogin/dto/JsonResponse.java
+++ b/src/main/java/com/project/securelogin/dto/JsonResponse.java
@@ -1,5 +1,7 @@
 package com.project.securelogin.dto;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
@@ -9,4 +11,16 @@ public class JsonResponse {
     private final int statusCode;
     private final String message;
     private UserResponseDTO data;
+
+    public String toJson() {
+        ObjectMapper mapper = new ObjectMapper();
+        try {
+            return mapper.writeValueAsString(this);
+        } catch (JsonProcessingException e) {
+            e.printStackTrace();
+            return "{}";
+        }
+    }
+
+
 }

--- a/src/main/java/com/project/securelogin/oauth/handler/OAuth2LoginFailureHandler.java
+++ b/src/main/java/com/project/securelogin/oauth/handler/OAuth2LoginFailureHandler.java
@@ -1,0 +1,29 @@
+package com.project.securelogin.oauth.handler;
+
+import com.project.securelogin.dto.JsonResponse;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.authentication.SimpleUrlAuthenticationFailureHandler;
+import org.springframework.stereotype.Component;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+@Component
+public class OAuth2LoginFailureHandler extends SimpleUrlAuthenticationFailureHandler {
+
+    @Override
+    public void onAuthenticationFailure(HttpServletRequest request,
+                                        HttpServletResponse response,
+                                        AuthenticationException exception) throws IOException {
+        JsonResponse jsonResponse = new JsonResponse(
+                HttpServletResponse.SC_UNAUTHORIZED,
+                "로그인 실패",
+                null
+        );
+
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+        response.setContentType("application/json");
+        response.getWriter().write(jsonResponse.toString());
+    }
+}

--- a/src/main/java/com/project/securelogin/oauth/handler/OAuth2LoginSuccessHandler.java
+++ b/src/main/java/com/project/securelogin/oauth/handler/OAuth2LoginSuccessHandler.java
@@ -1,0 +1,67 @@
+package com.project.securelogin.oauth.handler;
+
+import com.project.securelogin.domain.CustomOAuth2User;
+import com.project.securelogin.domain.CustomUserDetails;
+import com.project.securelogin.domain.User;
+import com.project.securelogin.dto.JsonResponse;
+import com.project.securelogin.dto.UserResponseDTO;
+import com.project.securelogin.jwt.JwtTokenProvider;
+import com.project.securelogin.oauth.userInfo.OAuth2UserInfo;
+import com.project.securelogin.oauth.userInfo.OAuth2UserInfoFactory;
+import com.project.securelogin.service.CustomOAuth2UserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
+import org.springframework.stereotype.Component;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+@Component
+@RequiredArgsConstructor
+public class OAuth2LoginSuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
+
+    private final JwtTokenProvider jwtTokenProvider;
+    private final CustomOAuth2UserService oAuth2UserService;
+
+    @Override
+    public void onAuthenticationSuccess(HttpServletRequest request,
+                                        HttpServletResponse response,
+                                        Authentication authentication) throws IOException {
+        // CustomOAuth2User 객체를 생성
+        CustomOAuth2User customOAuth2User = (CustomOAuth2User) authentication.getPrincipal();
+        String socialType = customOAuth2User.getSocialType();
+
+        // OAuth2UserInfo를 사용하여 사용자 정보를 가져옴
+        OAuth2UserInfo userInfo = OAuth2UserInfoFactory.getOAuth2UserInfo(socialType, customOAuth2User.getAttributes());
+
+        User user = oAuth2UserService.getUserByOAuth2UserInfo(userInfo, socialType);
+        CustomUserDetails userDetails = new CustomUserDetails(user);
+
+        // CustomUserDetails를 Authentication으로 변환
+        Authentication auth = new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
+        SecurityContextHolder.getContext().setAuthentication(auth);
+
+        String accessToken = jwtTokenProvider.createToken(auth);
+        String refreshToken = jwtTokenProvider.createRefreshToken(auth);
+
+        response.setHeader("Authorization", "Bearer " + accessToken);
+        response.setHeader("Refresh-Token", refreshToken);
+
+        JsonResponse jsonResponse = new JsonResponse(
+                HttpServletResponse.SC_OK,
+                "로그인 성공",
+                new UserResponseDTO(customOAuth2User.getName(), customOAuth2User.getEmail())
+        );
+
+        response.setContentType("application/json");
+        response.setCharacterEncoding("UTF-8");
+
+        response.getWriter().write(jsonResponse.toJson());
+    }
+}

--- a/src/main/java/com/project/securelogin/oauth/userInfo/GoogleOAuth2UserInfo.java
+++ b/src/main/java/com/project/securelogin/oauth/userInfo/GoogleOAuth2UserInfo.java
@@ -1,0 +1,25 @@
+package com.project.securelogin.oauth.userInfo;
+
+import java.util.Map;
+
+public class GoogleOAuth2UserInfo extends OAuth2UserInfo {
+
+    public GoogleOAuth2UserInfo(Map<String, Object> attributes) {
+        super(attributes);
+    }
+
+    @Override
+    public String getId() {
+        return (String) attributes.get("sub");
+    }
+
+    @Override
+    public String getName() {
+        return (String) attributes.get("name");
+    }
+
+    @Override
+    public String getEmail() {
+        return (String) attributes.get("email");
+    }
+}

--- a/src/main/java/com/project/securelogin/oauth/userInfo/KakaoOAuth2UserInfo.java
+++ b/src/main/java/com/project/securelogin/oauth/userInfo/KakaoOAuth2UserInfo.java
@@ -1,0 +1,29 @@
+package com.project.securelogin.oauth.userInfo;
+
+import java.util.Map;
+
+public class KakaoOAuth2UserInfo extends OAuth2UserInfo {
+
+    public KakaoOAuth2UserInfo(Map<String, Object> attributes) {
+        super(attributes);
+    }
+
+    @Override
+    public String getId() {
+        Object id = attributes.get("id");
+        return id != null ? id.toString() : null; // Long 타입을 String으로 변환
+    }
+
+    @Override
+    public String getName() {
+        Map<String, Object> account = (Map<String, Object>) attributes.get("kakao_account");
+        Map<String, Object> profile = (Map<String, Object>) account.get("profile");
+        return (String) profile.get("nickname");
+    }
+
+    @Override
+    public String getEmail() {
+        Map<String, Object> account = (Map<String, Object>) attributes.get("kakao_account");
+        return (String) account.get("email"); // 이메일이 존재하면 반환
+    }
+}

--- a/src/main/java/com/project/securelogin/oauth/userInfo/NaverOAuth2UserInfo.java
+++ b/src/main/java/com/project/securelogin/oauth/userInfo/NaverOAuth2UserInfo.java
@@ -1,0 +1,31 @@
+package com.project.securelogin.oauth.userInfo;
+
+import java.util.Map;
+
+public class NaverOAuth2UserInfo extends OAuth2UserInfo {
+
+    public NaverOAuth2UserInfo(Map<String, Object> attributes) {
+        super(attributes);
+    }
+
+    @Override
+    public String getId() {
+        // 네이버 응답에서 'response' 속성 내부의 'id' 값을 추출
+        Map<String, Object> response = (Map<String, Object>) attributes.get("response");
+        return (String) response.get("id");
+    }
+
+    @Override
+    public String getName() {
+        // 네이버 응답에서 'response' 속성 내부의 'name' 값을 추출
+        Map<String, Object> response = (Map<String, Object>) attributes.get("response");
+        return (String) response.get("name");
+    }
+
+    @Override
+    public String getEmail() {
+        // 네이버 응답에서 'response' 속성 내부의 'email' 값을 추출
+        Map<String, Object> response = (Map<String, Object>) attributes.get("response");
+        return (String) response.get("email");
+    }
+}

--- a/src/main/java/com/project/securelogin/oauth/userInfo/OAuth2UserInfo.java
+++ b/src/main/java/com/project/securelogin/oauth/userInfo/OAuth2UserInfo.java
@@ -1,0 +1,15 @@
+package com.project.securelogin.oauth.userInfo;
+
+import java.util.Map;
+
+public abstract class OAuth2UserInfo {
+    protected Map<String, Object> attributes;
+
+    public OAuth2UserInfo(Map<String, Object> attributes) {
+        this.attributes = attributes;
+    }
+
+    public abstract String getId();
+    public abstract String getName();
+    public abstract String getEmail();
+}

--- a/src/main/java/com/project/securelogin/oauth/userInfo/OAuth2UserInfoFactory.java
+++ b/src/main/java/com/project/securelogin/oauth/userInfo/OAuth2UserInfoFactory.java
@@ -1,0 +1,18 @@
+package com.project.securelogin.oauth.userInfo;
+
+import java.util.Map;
+
+public class OAuth2UserInfoFactory {
+
+    public static OAuth2UserInfo getOAuth2UserInfo(String registrationId, Map<String, Object> attributes) {
+        if ("google".equalsIgnoreCase(registrationId)) {
+            return new GoogleOAuth2UserInfo(attributes);
+        } else if ("kakao".equalsIgnoreCase(registrationId)) {
+            return new KakaoOAuth2UserInfo(attributes);
+        } else if ("naver".equalsIgnoreCase(registrationId)) {
+            return new NaverOAuth2UserInfo(attributes);
+        } else {
+            throw new IllegalArgumentException("Invalid registration ID");
+        }
+    }
+}

--- a/src/main/java/com/project/securelogin/repository/UserRepository.java
+++ b/src/main/java/com/project/securelogin/repository/UserRepository.java
@@ -13,6 +13,8 @@ public interface UserRepository extends JpaRepository<User, Long> {
 
     Optional<User> findByMailVerificationToken(String token);
 
+    Optional<User> findBySocialId(String socialId);
+
     boolean existsByEmail(String email);
 
 }

--- a/src/main/java/com/project/securelogin/service/CustomOAuth2UserService.java
+++ b/src/main/java/com/project/securelogin/service/CustomOAuth2UserService.java
@@ -1,0 +1,67 @@
+package com.project.securelogin.service;
+
+import com.project.securelogin.domain.CustomOAuth2User;
+import com.project.securelogin.domain.User;
+import com.project.securelogin.repository.UserRepository;
+import com.project.securelogin.oauth.userInfo.OAuth2UserInfo;
+import com.project.securelogin.oauth.userInfo.OAuth2UserInfoFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserService;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class CustomOAuth2UserService implements OAuth2UserService<OAuth2UserRequest, OAuth2User> {
+
+    private final UserRepository userRepository;
+
+    @Override
+    @Transactional
+    public OAuth2User loadUser(OAuth2UserRequest userRequest) {
+        String registrationId = userRequest.getClientRegistration().getRegistrationId();
+        OAuth2User oauth2User = getOAuth2User(userRequest);
+
+        OAuth2UserInfo userInfo = OAuth2UserInfoFactory.getOAuth2UserInfo(registrationId, oauth2User.getAttributes());
+
+        saveOrUpdateUser(userInfo, registrationId);
+
+
+        return new CustomOAuth2User(oauth2User, registrationId);
+    }
+
+    private OAuth2User getOAuth2User(OAuth2UserRequest userRequest) {
+        // 기본 OAuth2UserService를 사용하여 사용자 정보를 가져온다.
+        return new DefaultOAuth2UserService().loadUser(userRequest);
+    }
+
+
+    private User saveOrUpdateUser(OAuth2UserInfo userInfo, String registrationId) {
+        User user = userRepository.findBySocialId(userInfo.getId())
+                .orElseGet(() -> createNewUser(userInfo, registrationId));
+
+        // 업데이트할 필요가 있는 경우 필드 업데이트
+        user.updateOAuthUser(userInfo.getName(), userInfo.getEmail(), registrationId, userInfo.getId());
+
+        return userRepository.save(user);
+    }
+
+    private User createNewUser(OAuth2UserInfo userInfo, String registrationId) {
+        return User.builder()
+                .username(userInfo.getName())
+                .email(userInfo.getEmail()) // 이메일 추가
+                .socialType(registrationId)
+                .socialId(userInfo.getId())
+                .password("") // OAuth 로그인에서는 비밀번호가 필요 없으므로 빈 문자열로 설정
+                .enabled(true)
+                .build();
+    }
+
+    public User getUserByOAuth2UserInfo(OAuth2UserInfo userInfo, String registrationId) {
+        return userRepository.findBySocialId(userInfo.getId())
+                .orElseGet(() -> createNewUser(userInfo, registrationId));
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -8,6 +8,11 @@ spring:
     active: local
   application:
     name: secure-login
+  mvc:
+    web:
+      encoding:
+        charset: UTF-8
+        enabled: true
 
   jpa:
     hibernate:
@@ -19,6 +24,7 @@ spring:
 logging:
   level:
     org.jasypt: DEBUG
+    org.springframework.security: DEBUG
 
 jasypt:
   encryptor:


### PR DESCRIPTION
## Pull Request 요약

> _**`OAuth2` 로그인 기능 구현 (`Google`, `Kakao`, `Naver`)**_

프로젝트에  `OAuth2` 로그인 기능을 구현했습니다. 사용자는 `Google`, `Kakao`, `Naver`를 통해 로그인할 수 있으며, 데이터는 기존에 존재하던 `User` 테이블과 연동됩니다.

### 변경 사항

1. **SecurityConfig.java**
   - OAuth2 로그인 설정 추가
   - OAuth2 로그인 성공 및 실패 핸들러 추가

2. **CustomOAuth2User.java**
   - OAuth2 사용자 정보를 처리하는 클래스 추가

3. **User.java**
   - 소셜 타입과 소셜 ID 필드 추가
   - OAuth 사용자 업데이트 메서드 추가

4. **OAuth2LoginFailureHandler.java & OAuth2LoginSuccessHandler.java**
   - OAuth2 로그인 성공 및 실패 핸들러 구현

5. **CustomOAuth2UserService.java**
   - OAuth2 사용자 정보를 로드하고 데이터베이스에 저장하는 서비스 추가

6. **OAuth2UserInfo 클래스들 (GoogleOAuth2UserInfo, KakaoOAuth2UserInfo, NaverOAuth2UserInfo)**
   - 각 소셜 플랫폼별 사용자 정보 추출 클래스 추가

7. **OAuth2UserInfoFactory.java**
   - 소셜 플랫폼에 따라 적절한 OAuth2UserInfo 객체를 생성하는 팩토리 클래스 추가

8. **UserRepository.java**
   - 소셜 ID로 사용자를 조회하는 메서드 추가

9. **application.yml**
   - 인코딩 관련 설정 추가 `UTF-8`

### 관련 이슈

#10에 `OAuth2` 로그인 기능 추가

### 변경된 동작

- 사용자는 각 페이지에서 Google, Kakao, Naver를 통해 로그인할 수 있다.
  - `Google` 로그인 페이지: http://localhost:9090/oauth2/authorization/google
  - `Kakao` 로그인 페이지: http://localhost:9090/oauth2/authorization/kakao
  - `Naver` 로그인 페이지: http://localhost:9090/oauth2/authorization/naver

- 로그인 성공 시 `Header`엔 `JWT` 토큰이 발급되며, `Body`엔 `JsonResponse` 형태의 응답이 반환된다.

### 테스트 방법

1. 프로젝트를 실행한다.
2. Google, Kakao, Naver 중 하나를 선택하여 해당 로그인 페이지로 이동한다.
3. 성공 시 JWT 토큰이 응답 헤더에 포함되어 반환된다.
4. 실패 시 에러 메시지가 JSON 형식으로 반환된다.


### 기타 정보

- 각 소셜 플랫폼별로 Client ID와 Secret Key를 `application-oauth.yml` 파일에 설정했다. (`.gitignore` 적용)
- 추가적으로 커스텀 사용자 상세 정보나 권한 처리가 필요한 경우, `CustomOAuth2User` 및 `CustomUserDetails` 클래스를 확장할 수 있다.